### PR TITLE
Return Entry Animations

### DIFF
--- a/android/screens/src/main/kotlin/work/racka/reluct/android/screens/dashboard/overview/DashboardOverviewUI.kt
+++ b/android/screens/src/main/kotlin/work/racka/reluct/android/screens/dashboard/overview/DashboardOverviewUI.kt
@@ -193,6 +193,7 @@ internal fun DashboardOverviewUI(
                 // Upcoming Tasks
                 items(items = uiState.todayTasksState.pending, key = { it.id }) { item ->
                     TaskEntry(
+                        playAnimation = true,
                         modifier = Modifier.animateItemPlacement(),
                         task = item,
                         entryType = EntryType.TasksWithOverdue,

--- a/android/screens/src/main/kotlin/work/racka/reluct/android/screens/screentime/statistics/ScreenTimeStatisticsUI.kt
+++ b/android/screens/src/main/kotlin/work/racka/reluct/android/screens/screentime/statistics/ScreenTimeStatisticsUI.kt
@@ -240,6 +240,7 @@ internal fun ScreenTimeStatisticsUI(
                         key = { it.packageName }
                     ) { item ->
                         AppUsageEntry(
+                            playAnimation = true,
                             modifier = Modifier.animateItemPlacement(),
                             appUsageInfo = item,
                             onEntryClick = { onAppUsageInfoClick(item) },

--- a/android/screens/src/main/kotlin/work/racka/reluct/android/screens/tasks/done/CompletedTasksUI.kt
+++ b/android/screens/src/main/kotlin/work/racka/reluct/android/screens/tasks/done/CompletedTasksUI.kt
@@ -171,6 +171,7 @@ internal fun CompletedTasksUI(
                             key = { it.id }
                         ) { item ->
                             TaskEntry(
+                                playAnimation = true,
                                 task = item,
                                 entryType = EntryType.CompletedTask,
                                 onEntryClick = { onTaskClicked(item) },

--- a/android/screens/src/main/kotlin/work/racka/reluct/android/screens/tasks/pending/PendingTasksUI.kt
+++ b/android/screens/src/main/kotlin/work/racka/reluct/android/screens/tasks/pending/PendingTasksUI.kt
@@ -184,7 +184,8 @@ internal fun PendingTasksUI(
                                 task = item,
                                 entryType = EntryType.TasksWithOverdue,
                                 onEntryClick = { onTaskClicked(item) },
-                                onCheckedChange = { onToggleTaskDone(it, item) }
+                                onCheckedChange = { onToggleTaskDone(it, item) },
+                                playAnimation = true
                             )
                         }
                     }
@@ -201,7 +202,8 @@ internal fun PendingTasksUI(
                                 task = item,
                                 entryType = EntryType.PendingTask,
                                 onEntryClick = { onTaskClicked(item) },
-                                onCheckedChange = { onToggleTaskDone(it, item) }
+                                onCheckedChange = { onToggleTaskDone(it, item) },
+                                playAnimation = true
                             )
                         }
                     }

--- a/android/screens/src/main/kotlin/work/racka/reluct/android/screens/tasks/search/TasksSearchUI.kt
+++ b/android/screens/src/main/kotlin/work/racka/reluct/android/screens/tasks/search/TasksSearchUI.kt
@@ -136,6 +136,7 @@ internal fun TasksSearchUI(
                         key = { it.id }
                     ) { item ->
                         TaskEntry(
+                            playAnimation = true,
                             task = item,
                             entryType = EntryType.CompletedTask,
                             onEntryClick = { onTaskClicked(item) },

--- a/android/screens/src/main/kotlin/work/racka/reluct/android/screens/tasks/statistics/TasksStatisticsUI.kt
+++ b/android/screens/src/main/kotlin/work/racka/reluct/android/screens/tasks/statistics/TasksStatisticsUI.kt
@@ -186,7 +186,8 @@ internal fun TasksStatisticsUI(
                             task = item,
                             entryType = EntryType.TasksWithOverdue,
                             onEntryClick = { onTaskClicked(item) },
-                            onCheckedChange = { onToggleTaskDone(it, item) }
+                            onCheckedChange = { onToggleTaskDone(it, item) },
+                            playAnimation = true
                         )
                     }
                 }
@@ -204,7 +205,8 @@ internal fun TasksStatisticsUI(
                             task = item,
                             entryType = EntryType.CompletedTask,
                             onEntryClick = { onTaskClicked(item) },
-                            onCheckedChange = { onToggleTaskDone(it, item) }
+                            onCheckedChange = { onToggleTaskDone(it, item) },
+                            playAnimation = true
                         )
                     }
                 }


### PR DESCRIPTION
Entry animations aren't a big performance impact as previously expected. They only cause issues on very low end devices.

Re enable them for now and offer a toggle (later) to reduce animations in settings.