### PR TITLE
Remove Work around for failed MPP imports on Android Studio

### DIFF
--- a/desktop/app/build.gradle.kts
+++ b/desktop/app/build.gradle.kts
@@ -10,8 +10,7 @@ kotlin {
         compilations.all {
             kotlinOptions.jvmTarget = JavaVersion.VERSION_11.majorVersion
         }
-        // TODO: Fix on Electric Eel Beta03: https://issuetracker.google.com/issues/248593403
-        //withJava()
+        withJava()
     }
     sourceSets {
         val desktopMain by getting {


### PR DESCRIPTION
Related issue can be found here: https://issuetracker.google.com/issues/248593403

This has been fixed on Electric Eel Beta03